### PR TITLE
Adding explicit import of read_dot/modifying code

### DIFF
--- a/dot_find_cycles.py
+++ b/dot_find_cycles.py
@@ -17,6 +17,7 @@ Python
 python-networkx - <http://networkx.lanl.gov/> <= 1.10
 graphviz-python - <http://www.graphviz.org/>
 pydot - <http://code.google.com/p/pydot/>
+pydotplus - <http://pydotplus.readthedocs.io/>
 (all of these are available as native packages at least on CentOS)
 
 USAGE:
@@ -33,6 +34,7 @@ CHANGELOG:
 import sys
 from os import path, access, R_OK
 import networkx as nx
+from networkx.drawing.nx_pydot import read_dot
 
 def usage():
     sys.stderr.write("dot_find_cycles.py by Jason Antman <http://blog.jasonantman.com>\n")
@@ -57,7 +59,7 @@ def main():
 
 
     # read in the specified file, create a networkx DiGraph
-    G = nx.DiGraph(nx.read_dot(path))
+    G = nx.DiGraph(read_dot(path))
 
     C = nx.simple_cycles(G)
     for i in C:


### PR DESCRIPTION
Implementing a workaround to a networkx bug that was introduced after this was published.  See https://github.com/networkx/networkx/issues/1984 for more information.  Along with explicitly importing read_dot, you need to install pydotplus.  Unsure if pydot is still required as I didn't test on a host without it.
